### PR TITLE
fix(readme): Update Windows Git clone installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ git clone https://github.com/NvChad/tinyvim ~/.config/nvim && nvim
 
 - Windows
 ```bash
-git clone https://github.com/NvChad/NvChad $HOME\AppData\Local\nvim --depth 1 && nvim
+git clone https://github.com/NvChad/tinyvim $HOME\AppData\Local\nvim --depth 1 && nvim
 ```
 
 # About


### PR DESCRIPTION
I assume the clone should be the tinyvim repo instead of the NvChad repo for the Windows installation.