### PR TITLE
Move nvim-treesitter to its main branch 

### DIFF
--- a/lua/commands.lua
+++ b/lua/commands.lua
@@ -2,3 +2,18 @@
 vim.api.nvim_create_user_command("MasonInstallAll", function()
   vim.cmd "MasonInstall css-lsp html-lsp lua-language-server typescript-language-server stylua prettier"
 end, {})
+
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "*",
+  callback = function ()
+    pcall(vim.treesitter.start)
+  end
+})
+
+local create_cmd = vim.api.nvim_create_user_command
+
+create_cmd("TSInstallAll", function()
+  local spec = require("lazy.core.config").plugins["nvim-treesitter"]
+  local opts = type(spec.opts()) == "table" and spec.opts() or {}
+  require("nvim-treesitter").install(opts.ensure_installed)
+end, {})

--- a/lua/plugins/configs/treesitter.lua
+++ b/lua/plugins/configs/treesitter.lua
@@ -1,9 +1,3 @@
-require("nvim-treesitter.configs").setup {
-  ensure_installed = { "lua", "vim", "vimdoc", "html", "css", "typescript", "javascript" },
-
-  highlight = {
-    enable = true,
-    use_languagetree = true,
-  },
-  indent = { enable = true },
+return {
+  ensure_installed = { "lua", "luadoc", "printf", "vim", "vimdoc" },
 }

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -15,9 +15,9 @@ return {
 
   {
     "nvim-treesitter/nvim-treesitter",
-    build = ":TSUpdate",
-    config = function()
-      require "plugins.configs.treesitter"
+    build = ":TSUpdate | TSInstallAll",
+    opts = function()
+      return require "plugins.configs.treesitter"
     end,
   },
 


### PR DESCRIPTION
Hello! Not sure if anyone still uses tinyvim or not, but I really like how it's set up! Unfortunately I was installing it on a fresh machine and was getting this frustrating error.
<img width="1598" height="554" alt="image" src="https://github.com/user-attachments/assets/7a72977c-c4cd-4ae4-8149-a77b799e3a66" />

Turns out its from nvim-treesitter being completely rewritten, and now you have to explicitly say you want the old master branch if you want to use the old nvim-treesitter. This is the quick fix, ideally a better one would be to move completely over to the new main branch and rewrite the setup for treesitter. I'll likely do this on my own fork sometime in the future. 

If anyone would want a generic port of treesitter to its main for upstream tinyvim, I can make a PR here as well for that when I get around to it.